### PR TITLE
add monitor process for ejabberd

### DIFF
--- a/common/print_recon_proc_count_memory.erl
+++ b/common/print_recon_proc_count_memory.erl
@@ -1,5 +1,26 @@
 echo(off),
-io:format("~p~n", [[{X/1024/1024, recon:info(P)} || {P, X, _} <-  recon:proc_count(memory, 3)]]),
-io:format("~p~n", [recon_alloc:memory(usage)]),
+io:format("========================================~n"),
+io:format("time : ~p~n", [erlang:localtime()]),
+io:format("---> memory proc count info~n"),
+[begin
+    io:format("~p~n", [[Proc, {'memory(M)', Memory/1024/1024}, recon:info(Proc, registered_name),
+                        recon:info(Proc, current_location), recon:info(Proc, current_function)]])
+ end || {Proc, Memory, _} <- recon:proc_count(memory, 5)],
+io:format("---> reductions proc window info~n"),
+[begin
+    io:format("~p~n", [[Proc, {'reductionwindow', ReductionsWindow}, recon:info(Proc, registered_name),
+                        recon:info(Proc, current_location), recon:info(Proc, current_function)]])
+ end || {Proc, ReductionsWindow, _} <- recon:proc_window(reductions, 5, 500)],
+io:format("---> message_queue_len proc count info~n"),
+[begin
+    io:format("~p~n", [[Proc, {'message_queue_len', MsgQueueLen}, recon:info(Proc, registered_name),
+                        recon:info(Proc, current_location), recon:info(Proc, current_function)]])
+ end || {Proc, MsgQueueLen, _} <- recon:proc_count(message_queue_len, 5)],
+io:format("---> binary leak info~n"),
+[begin
+    io:format("~p~n", [[Proc, {'bin_leak', BinLeak}, recon:info(Proc, registered_name),
+                        recon:info(Proc, current_location), recon:info(Proc, current_function)]])
+ end || {Proc, BinLeak, _} <- recon:bin_leak(5)],
+io:format("---> total erlang process num~n"),
+io:format("~p~n", [erlang:length(erlang:processes())]),
 ok.
-


### PR DESCRIPTION
add monitor for ejabberd erlang process in:
- memory
- reductions
- message queue len
- bin leak

reductions using `proc_window/3` function

> The reduction count has a direct link to function calls in Erlang, and a high count is usually the synonym of a high amount of CPU usage.
>
> What’s interesting with this function is to try it while a system is already rather busy, with a relatively short interval. Repeat it many times, and you should hopefully see a pattern emerge where the same processes (or the same kind of processes) tend to always come up on top.
>
> Using the code locations and current functions being run, you should be able to identify what kind of code hogs all your schedulers.

from `<<Erlang in Anger>>`